### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ frag hello(name)
     p Hello, #(name).
     content
 
-let values = data/values.json
+let values = ./data/values.json
 ul
   for value in values
     hello(value['username'])


### PR DESCRIPTION
When running the first README example, slab just hangs without rendering.

Changing this:

```
let values = data/values.json
```

to this

```
let values = ./data/values.json
```

fixes the problem.

It would be nice if this works without this prefix though.